### PR TITLE
adding optional "raw" modified to sign/verify APIs to allow signing of raw transaction hashes

### DIFF
--- a/API.md
+++ b/API.md
@@ -11,7 +11,6 @@ Vault provides a CLI that wraps the Vault REST interface. Any HTTP client (inclu
 * [Import Account](https://github.com/immutability-io/vault-ethereum/blob/master/API.md#import-account)
 * [Export Account](https://github.com/immutability-io/vault-ethereum/blob/master/API.md#export-account)
 * [Deploy Ethereum Contract](https://github.com/immutability-io/vault-ethereum/blob/master/API.md#deploy-ethereum-contract)
-* [Sign Raw Data](https://github.com/immutability-io/vault-ethereum/blob/master/API.md#sign-raw-data)
 * [Sign Data](https://github.com/immutability-io/vault-ethereum/blob/master/API.md#sign-data)
 * [Send Ethereum/Debit Account](https://github.com/immutability-io/vault-ethereum/blob/master/API.md#send-ethereumdebit-account)
 
@@ -559,6 +558,7 @@ This endpoint will sign the provided data.
 
 * `name` (`string: <required>`) - Specifies the name of the account to use for signing. This is specified as part of the URL.
 * `data` (`string: <required>`) - Some data.
+* `raw` (`boolean: <optional>- defaults to false`) - if true, data is expected to be raw hashed transaction data in hex encoding; otherwise data is treated as regular text
 
 #### Sample Payload
 
@@ -610,6 +610,7 @@ This endpoint will verify that this account signed some data.
 
 * `name` (`string: <required>`) - Specifies the name of the account to use for signing. This is specified as part of the URL.
 * `data` (`string: <required>`) - Some data.
+* `raw` (`boolean: <optional>- defaults to false`) - if true, data is expected to be raw hashed transaction data in hex encoding; otherwise data is treated as regular text
 * `signature` (`string: <required>`) - The signature to verify.
 
 #### Sample Payload

--- a/API.md
+++ b/API.md
@@ -11,6 +11,7 @@ Vault provides a CLI that wraps the Vault REST interface. Any HTTP client (inclu
 * [Import Account](https://github.com/immutability-io/vault-ethereum/blob/master/API.md#import-account)
 * [Export Account](https://github.com/immutability-io/vault-ethereum/blob/master/API.md#export-account)
 * [Deploy Ethereum Contract](https://github.com/immutability-io/vault-ethereum/blob/master/API.md#deploy-ethereum-contract)
+* [Sign Raw Data](https://github.com/immutability-io/vault-ethereum/blob/master/API.md#sign-raw-data)
 * [Sign Data](https://github.com/immutability-io/vault-ethereum/blob/master/API.md#sign-data)
 * [Send Ethereum/Debit Account](https://github.com/immutability-io/vault-ethereum/blob/master/API.md#send-ethereumdebit-account)
 
@@ -494,6 +495,57 @@ $ curl -s --cacert /etc/vault.d/root.crt --header "X-Vault-Token: $VAULT_TOKEN" 
   "auth": null
 }
 ```
+
+### SIGN RAW DATA
+
+This endpoint will sign raw hashed transaction data.
+
+| Method  | Path | Produces |
+| ------------- | ------------- | ------------- |
+| `POST`  | `:mount-path/accounts/:name/sign-raw`  | `200 application/json` |
+
+#### Parameters
+
+* `name` (`string: <required>`) - Specifies the name of the account to use for signing. This is specified as part of the URL.
+* `data` (`string: <required>`) - Some raw hashed transaction data in hex encoding.
+
+#### Sample Payload
+
+```sh
+
+{
+  "data": "0xda6da96f071d617aacdaeda8a320ed4d6268907a64020d93718acde071daf584"
+}
+```
+
+#### Sample Request
+
+```sh
+$ curl -s --cacert /etc/vault.d/root.crt --header "X-Vault-Token: $VAULT_TOKEN" \
+    --request POST \
+    --data @payload.json \
+    https://localhost:8200/v1/ethereum/accounts/test2/sign | jq .
+```
+
+#### Sample Response
+
+The example below shows output for the successful signing of raw hashed transaction data by the private key associated with  `/ethereum/accounts/test2`.
+
+```
+{
+  "request_id": "5491a21c-7541-f48c-d573-0d241f12bfd3",
+  "lease_id": "",
+  "renewable": false,
+  "lease_duration": 0,
+  "data": {
+    "signature": "0x56cf03f25e18bd78f4ed0e39de0da0c01bcc810ae264f962cbfc9da80da0f4e0539209948ac168cda37f3100dc4d1bbfe5920169fdddbb5dec421f2e6af5a9d001"
+  },
+  "wrap_info": null,
+  "warnings": null,
+  "auth": null
+}
+```
+
 
 ### SIGN DATA
 

--- a/API.md
+++ b/API.md
@@ -495,57 +495,6 @@ $ curl -s --cacert /etc/vault.d/root.crt --header "X-Vault-Token: $VAULT_TOKEN" 
 }
 ```
 
-### SIGN RAW DATA
-
-This endpoint will sign raw hashed transaction data.
-
-| Method  | Path | Produces |
-| ------------- | ------------- | ------------- |
-| `POST`  | `:mount-path/accounts/:name/sign-raw`  | `200 application/json` |
-
-#### Parameters
-
-* `name` (`string: <required>`) - Specifies the name of the account to use for signing. This is specified as part of the URL.
-* `data` (`string: <required>`) - Some raw hashed transaction data in hex encoding.
-
-#### Sample Payload
-
-```sh
-
-{
-  "data": "0xda6da96f071d617aacdaeda8a320ed4d6268907a64020d93718acde071daf584"
-}
-```
-
-#### Sample Request
-
-```sh
-$ curl -s --cacert /etc/vault.d/root.crt --header "X-Vault-Token: $VAULT_TOKEN" \
-    --request POST \
-    --data @payload.json \
-    https://localhost:8200/v1/ethereum/accounts/test2/sign | jq .
-```
-
-#### Sample Response
-
-The example below shows output for the successful signing of raw hashed transaction data by the private key associated with  `/ethereum/accounts/test2`.
-
-```
-{
-  "request_id": "5491a21c-7541-f48c-d573-0d241f12bfd3",
-  "lease_id": "",
-  "renewable": false,
-  "lease_duration": 0,
-  "data": {
-    "signature": "0x56cf03f25e18bd78f4ed0e39de0da0c01bcc810ae264f962cbfc9da80da0f4e0539209948ac168cda37f3100dc4d1bbfe5920169fdddbb5dec421f2e6af5a9d001"
-  },
-  "wrap_info": null,
-  "warnings": null,
-  "auth": null
-}
-```
-
-
 ### SIGN DATA
 
 This endpoint will sign the provided data.

--- a/main.go
+++ b/main.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/vault/helper/pluginutil"
 	"github.com/hashicorp/vault/logical"
 	"github.com/hashicorp/vault/logical/plugin"
-	"github.com/trustroot/vault-ethereum/ethereum"
+	"github.com/immutability-io/vault-ethereum/ethereum"
 )
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/vault/helper/pluginutil"
 	"github.com/hashicorp/vault/logical"
 	"github.com/hashicorp/vault/logical/plugin"
-	"github.com/immutability-io/vault-ethereum/ethereum"
+	"github.com/trustroot/vault-ethereum/ethereum"
 )
 
 func main() {


### PR DESCRIPTION
## Description
This PR adds a new `sign-raw` API under `accounts` path to allow signing of raw transaction hashes.

This new API is modeled after the existing sign API, with the main difference being that input is a raw transaction already hashed instead of free-text message to be signed.

## Motivation and Context
One of the benefits of using vault-ethereum plugin, is the ability to never need to expose secret information of accounts such as their private key in other parts of your infrastructure while still being able to perform all necessary actions against the accounts in question.

One such action is signing of variety of different transactions that one might want to execute against the network.

By adding this API, the caller can construct any raw transaction in their desired library/application and simply send the transaction binary hash to Vault for signature. Once she receives the signature back, it can be sent to desired Ethereum client node on the network, which will propagate the transaction out to other nodes. All of this can now happen without the private key needing to leave the secure walls of Vault.

## How Has This Been Tested?
This is a brand new API and does not impact any existing code. I have tested creating raw transactions in web3j, signing using this API, and executing the signed transaction against a `Ganache CLI v6.1.0 (ganache-core: 2.1.0)` client successfully.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Documentation enhancement
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
