### PR TITLE
Fix missing apostrophe in API docs

### DIFF
--- a/API.md
+++ b/API.md
@@ -143,7 +143,7 @@ The example below shows output for the successful creation of `/ethereum/account
 
 ### UPDATE ACCOUNT
 
-This endpoint will update an accounts constraints.
+This endpoint will update an account's constraints.
 
 | Method  | Path | Produces |
 | ------------- | ------------- | ------------- |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Simply a docs change to possessiveness to a word.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I'm proofreading while getting my dev environment set up. We should probably open a generic "docs" issue label.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Technically no.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Documentation enhancement
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.

PS: I don't think you have a contributing document?