### PR TITLE
 ability to sign transactions without sending them - default is to send

### DIFF
--- a/API.md
+++ b/API.md
@@ -329,12 +329,12 @@ The example below shows the output for the successfully sending ETH from `/ether
     "amount": "100000000000000000",
     "amount_in_usd": "0",
     "address_from": "0x4169c9508728285e8a9f7945d08645bb6b3576e5",
+    "address_to": "0x8AC5e6617F65c071f6dD5d7bD400bf4a46434D41",
     "gas_limit": "21000",
     "gas_price": "1000000000",
     "signed_transaction": "0xf86b06843b9aca00825208948ac5e6617f65c071f6dd5d7bd400bf4a46434d4188016345785d8a0000802ca0ff3fccbde1964047db6be33410436a9220c91ea4080b0e14489dc35fbdabd008a0448fe3ec216a639e1b0eb87b0e4b20aab2e5ec46dad4c38cfc81a1c54e309d21",
     "starting_balance": 8460893507395267000,
     "starting_balance_in_usd": "0",
-    "address_to": "0x8AC5e6617F65c071f6dD5d7bD400bf4a46434D41",
     "total_spend": "100000000000000000",
     "transaction_hash": "0x3a103587ea6bdeee944e5f68f90ed7b1f4c7699236167d1b1d29495b0319fb26"
   },

--- a/API.md
+++ b/API.md
@@ -287,6 +287,7 @@ This endpoint will debit an Ethereum account.
 * `amount` (`string: <required>`) - The amount of ether - in wei.
 * `gas_price` (`string: <optional>`) - The price in gas for the transaction. If omitted, we will use the suggested gas price.
 * `gas_limit` (`string: <optional>`) - The gas limit for the transaction. If omitted, we will estimate the gas limit.
+* `send` (`bool: <optional - defaults to true>`) - Indicates whether the transaction should be sent to the network. 
 
 #### Sample Payload
 
@@ -315,21 +316,22 @@ The example below shows the output for the successfully sending ETH from `/ether
 
 ```
 {
-  "request_id": "ac79079d-9e8c-e340-b718-fe19a27ff914",
+  "request_id": "b921207e-c0d9-a3c1-442b-ef8b1884238d",
   "lease_id": "",
   "lease_duration": 0,
   "renewable": false,
   "data": {
-    "amount": "200000000000000000"
-    "amount_in_usd": 59.8820422884
-    "from_address": "0x7b715f8748ef586b98d3e7c88f326b5a8f409cd8"
-    "gas_limit": "21000"
-    "gas_price": "2000000000"
-    "starting_balance": "1000000000000000000"
-    "starting_balance_in_usd": 299.410211442
-    "to_address": "0x36D1F896E55a6577C62FDD6b84fbF74582266700"
-    "total_spend": "200000000000000000"
-    "transaction_hash": "0x0b4938a1a44f545deeea500d50761c22bfe2bc006b26be8adf4dcd4fc0597769"
+    "amount": "100000000000000000",
+    "amount_in_usd": "0",
+    "address_from": "0x4169c9508728285e8a9f7945d08645bb6b3576e5",
+    "gas_limit": "21000",
+    "gas_price": "1000000000",
+    "signed_transaction": "0xf86b06843b9aca00825208948ac5e6617f65c071f6dd5d7bd400bf4a46434d4188016345785d8a0000802ca0ff3fccbde1964047db6be33410436a9220c91ea4080b0e14489dc35fbdabd008a0448fe3ec216a639e1b0eb87b0e4b20aab2e5ec46dad4c38cfc81a1c54e309d21",
+    "starting_balance": 8460893507395267000,
+    "starting_balance_in_usd": "0",
+    "address_to": "0x8AC5e6617F65c071f6dD5d7bD400bf4a46434D41",
+    "total_spend": "100000000000000000",
+    "transaction_hash": "0x3a103587ea6bdeee944e5f68f90ed7b1f4c7699236167d1b1d29495b0319fb26"
   },
   "warnings": null
 }
@@ -396,6 +398,7 @@ This endpoint will sign a provided Ethereum contract.
 * `nonce` (`string: <optional> - defaults to "1"`) - The nonce for the transaction
 * `gas_price` (`string: <required>`) - The price in gas for the transaction in wei.
 * `gas_limit` (`string: <required>`) - The gas limit for the transaction.
+* `send` (`bool: <optional - defaults to true>`) - Indicates whether the transaction should be sent to the network. 
 
 #### Sample Payload
 

--- a/README.md
+++ b/README.md
@@ -408,12 +408,12 @@ Key                       Value
 ---                       -----
 amount                    200000000000000000
 amount_in_usd             0
-from_address              0x7b715f8748ef586b98d3e7c88f326b5a8f409cd8
+address_from              0x7b715f8748ef586b98d3e7c88f326b5a8f409cd8
 gas_limit                 21000
 gas_price                 2000000000
 starting_balance          1000000000000000000
 starting_balance_in_usd   0
-to_address                0x36D1F896E55a6577C62FDD6b84fbF74582266700
+address_to                0x36D1F896E55a6577C62FDD6b84fbF74582266700
 total_spend               200000000000000000
 transaction_hash          0x0b4938a1a44f545deeea500d50761c22bfe2bc006b26be8adf4dcd4fc0597769
 ```

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Since Immutability's Ethereum Wallet has several unauthenticated endpoints ([det
 
 ### ETH Unit Converter
 
-[There is a website](https://etherconverter.online/) that will convert any ETH unit to any other. Since Immutability's Ethereum Wallet only allows you to send ETH in wei, I thought it would be useful to replicate this capability:
+[There is a website](https://etherconverter.online/) that will convert any ETH unit to any other. Since Immutability's Ethereum Wallet only allows you to send ETH in wei, I thought it would be useful to replicate this capability. **NOTE** we can also get the current average exchange value but converting any unit to USD. We can also convert from USD to any unit:
 
 ```
 $ vault write ethereum/convert unit_from="wei" unit_to="tether" amount="4.4"
@@ -221,6 +221,14 @@ amount_from    4.4
 amount_to      4400000000000000000
 unit_from      ether
 unit_to        wei
+
+$ vault write ethereum/convert amount=1 unit_from=eth unit_to=usd
+Key            Value
+---            -----
+amount_from    1
+amount_to      224.982648392
+unit_from      ether
+unit_to        usd
 ```
 
 All known ETH units are supported.
@@ -403,17 +411,19 @@ unit_to        wei
 Now, we send the ETH from the `muchwow` account to the address of the `lesswow` account. I use suggested gas price and the default gas limit of 21000.
 
 ```
+
 $ vault write ethereum/accounts/muchwow/debit amount=200000000000000000 address_to="0x36d1f896e55a6577c62fdd6b84fbf74582266700"
 Key                       Value
 ---                       -----
 amount                    200000000000000000
 amount_in_usd             0
 address_from              0x7b715f8748ef586b98d3e7c88f326b5a8f409cd8
+address_to                0x36D1F896E55a6577C62FDD6b84fbF74582266700
 gas_limit                 21000
 gas_price                 2000000000
+signed_transaction        0xf86b07843b9aca00825208948440a3f9243b96cd934de1b7a400368d880b041d88016345785d8a0000802ca0c8f2511d337ce9180deb525fb714100157a89fba7e990677f74609dde74bad21a0239b33f6439b28a9f9d9e8cbbb45fd77e1c1dddc33d16c07345667ee12d2a767
 starting_balance          1000000000000000000
 starting_balance_in_usd   0
-address_to                0x36D1F896E55a6577C62FDD6b84fbF74582266700
 total_spend               200000000000000000
 transaction_hash          0x0b4938a1a44f545deeea500d50761c22bfe2bc006b26be8adf4dcd4fc0597769
 ```

--- a/helper/hot.sh
+++ b/helper/hot.sh
@@ -22,7 +22,7 @@ fi
 cp -r $COLD_STORAGE/etc $HOME/etc
 nohup /usr/local/bin/vault server -config $HOME/etc/vault.d/vault.hcl &> /dev/null &
 
-mv $COLD_STORAGE/"$KEYBASE_USER"_* .
+cp $COLD_STORAGE/"$KEYBASE_USER"_* .
 vault operator unseal $(keybase decrypt -i $KEYBASE_USER"_UNSEAL_1.txt")
 vault operator unseal $(keybase decrypt -i $KEYBASE_USER"_UNSEAL_2.txt")
 vault operator unseal $(keybase decrypt -i $KEYBASE_USER"_UNSEAL_3.txt")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
A feature was requested that the plugin be able to sign transactions. Since this capability already existed in the context of `debit`, `contract deploy`, and `erc20 transfer` operations, it was thought to extend these features by adding a flag that can inhibit the sending of the transaction. In any case, the signed transaction is returned.

## Motivation and Context
Developer ease of use - if a developer only wants to sign transactions, that capability should be allowed.

## How Has This Been Tested?
Call the `debit`, `contract deploy`, and `erc20 transfer` operations with `send=false` and with the default `send=true`.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Documentation enhancement
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
