### PR TITLE
Endpoint for signing transactions in json format

### DIFF
--- a/API.md
+++ b/API.md
@@ -556,7 +556,6 @@ This endpoint will sign transaction.
 * `tx_data` (`string: <optional>`) - Transaction data in HEX string.
 * `gas_limit` (`string: <optional>`) - The gas limit for the transaction - defaults to 21000.
 * `gas_price` (`string: <optional>`) - The gas price for the transaction in wei. Default - 0.
-* `chain_id` (`string: <required>`) - Specifies the Ethereum network.
 
 #### Sample Payload
 

--- a/API.md
+++ b/API.md
@@ -10,7 +10,8 @@ Vault provides a CLI that wraps the Vault REST interface. Any HTTP client (inclu
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`    ├── accounts `&nbsp;&nbsp;([list](./API.md#list-accounts))  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`    │   └── <NAME> `&nbsp;&nbsp;([create](./API.md#create-account), [update](./API.md#update-account), [read](./API.md#read-account), [delete](./API.md#delete-account))  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`    │       ├── debit `&nbsp;&nbsp;([update](./API.md#debit-account))  
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`    │       ├── sign `&nbsp;&nbsp;([update](./API.md#sign))  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`    │       ├── sign `&nbsp;&nbsp;([update](./API.md#sign))
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`    │       ├── sign-tx `&nbsp;&nbsp;([update](./API.md#sign-tx))
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`    │       ├── transfer `&nbsp;&nbsp;([update](./API.md#transfer))  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`    │       └── verify `&nbsp;&nbsp;([update](./API.md#verify))  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`    ├── addresses `&nbsp;&nbsp;([list](./API.md#list-addresses))  
@@ -537,6 +538,72 @@ The example below shows output for the successful signing of some data by the pr
   "warnings": null,
   "auth": null
 }
+```
+
+### SIGN-TX
+
+This endpoint will sign transaction.
+
+| Method  | Path | Produces |
+| ------------- | ------------- | ------------- |
+| `POST`  | `:mount-path/accounts/:name/sign-tx`  | `200 application/json` |
+
+#### Parameters
+* `name` (`string: <required>`) - Specifies the name of the account to use for signing. This is specified as part of the URL.
+* `nonce` (`string: <required>`) - The nonce for the transaction.
+* `address_to` (`string: <required>`) - The address of the account to send ETH to.
+* `value` (`string: <required>`) - Value of ETH (in wei).
+* `tx_data` (`string: <optional>`) - Transaction data in HEX string.
+* `gas_limit` (`string: <optional>`) - The gas limit for the transaction - defaults to 21000.
+* `gas_price` (`string: <optional>`) - The gas price for the transaction in wei. Default - 0.
+* `chain_id` (`string: <required>`) - Specifies the Ethereum network.
+
+#### Sample Payload
+
+```json
+
+{
+  "nonce":"1",
+  "gas_price":"1000000000000000000",
+  "gas_limit":"21000",
+  "address_to":"0xF4E6e6fa97E10ddc057c94F501B94C1d24EF85Aa",
+  "value":"9000000000000000000",
+  "tx_data":"0x",
+  "chain_id":3
+}
+
+```
+
+#### Sample Request
+
+```sh
+$ curl -s --cacert ~/etc/vault.d/root.crt --header "X-Vault-Token: $VAULT_TOKEN" \
+    --request POST \
+    --data @payload.json \
+    https://localhost:8200/v1/ethereum/accounts/main/sign-tx | jq .
+```
+
+#### Sample Response
+
+The example below shows output for the successful signing of transaction by the private key associated with  `/ethereum/accounts/main`.
+Signed raw transaction in hex format and ready for broadcasting to network.
+
+```json
+
+{
+  "request_id": "61b9b5c8-866f-99d6-97f6-5ee0b6489a35",
+  "lease_id": "",
+  "renewable": false,
+  "lease_duration": 0,
+  "data": {
+    "address": "0x84b1858e0bdd6346db6d0f14b574b9be243cc4da",
+    "signed_tx": "0xf86f01880de0b6b3a764000082520894f4e6e6fa97e10ddc057c94f501b94c1d24ef85aa887ce66c50e28400008029a043e16edbcaf7c066372fc7eb665d1fe04cf254303df142ccf64c332c730bfac5a0794263d33fd9ed8770aeb534f6a9de513366cce278589c6d2623845c6f901b84"
+  },
+  "wrap_info": null,
+  "warnings": null,
+  "auth": null
+}
+
 ```
 
 ### TRANSFER

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Vault is a REST server. Services can be permissioned on granular basis according
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`    │   └── <NAME> `&nbsp;&nbsp;([create](./API.md#create-account), [update](./API.md#update-account), [read](./API.md#read-account), [delete](./API.md#delete-account))  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`    │       ├── debit `&nbsp;&nbsp;([update](./API.md#debit-account))  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`    │       ├── sign `&nbsp;&nbsp;([update](./API.md#sign))  
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`    │       ├── transfer `&nbsp;&nbsp;([update](./API.md#transfer))  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`    │       ├── sign-tx `&nbsp;&nbsp;([update](./API.md#sign-tx))
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`    │       ├── transfer `&nbsp;&nbsp;([update](./API.md#transfer))
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`    │       └── verify `&nbsp;&nbsp;([update](./API.md#verify))  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`    ├── addresses `&nbsp;&nbsp;([list](./API.md#list-addresses))  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`    │   └── <ADDRESS> `&nbsp;&nbsp;([read](./API.md#read-address))  
@@ -646,3 +647,4 @@ This code is licensed under the Apache 2 license. Please feel free to use it. Pl
 Send ETH to 0x4169c9508728285e8A9f7945D08645Bb6b3576e5 and you will be blessed in the next life.
 
 ![Donations Accepted](/docs/0x4169c9508728285e8A9f7945D08645Bb6b3576e5.png?raw=true "0x4169c9508728285e8A9f7945D08645Bb6b3576e5")
+

--- a/path_accounts.go
+++ b/path_accounts.go
@@ -234,20 +234,6 @@ Sign data using a given Ethereum account.
 					Description: "The gas price for the transaction in wei.",
 					Default:     "0",
 				},
-				"chain_id": &framework.FieldSchema{
-					Type: framework.TypeString,
-					Description: `Ethereum network - can be one of the following values:
-
-					1 - Ethereum mainnet
-					2 - Morden (disused), Expanse mainnet
-					3 - Ropsten
-					4 - Rinkeby
-					30 - Rootstock mainnet
-					31 - Rootstock testnet
-					42 - Kovan
-					61 - Ethereum Classic mainnet
-					62 - Ethereum Classic testnet`,
-				},
 			},
 			ExistenceCheck: b.pathExistenceCheck,
 			Callbacks: map[logical.Operation]framework.OperationFunc{
@@ -734,7 +720,7 @@ func (b *EthereumBackend) pathSign(ctx context.Context, req *logical.Request, da
 }
 
 func (b *EthereumBackend) pathSignTx(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
-	_, err := b.configured(ctx, req)
+	config, err := b.configured(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -754,7 +740,7 @@ func (b *EthereumBackend) pathSignTx(ctx context.Context, req *logical.Request, 
 		return nil, fmt.Errorf("invalid value")
 	}
 
-	chainID := ValidNumber(data.Get("chain_id").(string))
+	chainID := ValidNumber(config.ChainID)
 	if chainID == nil {
 		return nil, fmt.Errorf("invalid chain ID")
 	}

--- a/path_accounts.go
+++ b/path_accounts.go
@@ -199,6 +199,61 @@ Sign data using a given Ethereum account.
 				logical.CreateOperation: b.pathSign,
 			},
 		},
+		&framework.Path{
+			Pattern:      "accounts/" + framework.GenericNameRegex("name") + "/sign-tx",
+			HelpSynopsis: "Sign raw transaction data in json format.",
+			HelpDescription: `
+				Sign transaction json data using a given Ethereum account. 
+				Result will be a raw transaction ready for publishing in network.`,
+			Fields: map[string]*framework.FieldSchema{
+				"name": &framework.FieldSchema{Type: framework.TypeString},
+				"nonce": &framework.FieldSchema{
+					Type:        framework.TypeString,
+					Description: "The nonce for the transaction.",
+				},
+				"address_to": &framework.FieldSchema{
+					Type:        framework.TypeString,
+					Description: "The address of the account to send ETH to.",
+				},
+				"value": &framework.FieldSchema{
+					Type:        framework.TypeString,
+					Description: "Value of ETH (in wei).",
+				},
+				"tx_data": &framework.FieldSchema{
+					Type:        framework.TypeString,
+					Description: "Transaction data in HEX string.",
+					Default:     "0x",
+				},
+				"gas_limit": &framework.FieldSchema{
+					Type:        framework.TypeString,
+					Description: "The gas limit for the transaction - defaults to 21000.",
+					Default:     "21000",
+				},
+				"gas_price": &framework.FieldSchema{
+					Type:        framework.TypeString,
+					Description: "The gas price for the transaction in wei.",
+					Default:     "0",
+				},
+				"chain_id": &framework.FieldSchema{
+					Type: framework.TypeString,
+					Description: `Ethereum network - can be one of the following values:
+
+					1 - Ethereum mainnet
+					2 - Morden (disused), Expanse mainnet
+					3 - Ropsten
+					4 - Rinkeby
+					30 - Rootstock mainnet
+					31 - Rootstock testnet
+					42 - Kovan
+					61 - Ethereum Classic mainnet
+					62 - Ethereum Classic testnet`,
+				},
+			},
+			ExistenceCheck: b.pathExistenceCheck,
+			Callbacks: map[logical.Operation]framework.OperationFunc{
+				logical.CreateOperation: b.pathSignTx,
+			},
+		},
 	}
 }
 
@@ -673,6 +728,82 @@ func (b *EthereumBackend) pathSign(ctx context.Context, req *logical.Request, da
 	return &logical.Response{
 		Data: map[string]interface{}{
 			"signature": hexutil.Encode(signature),
+			"address":   account.Address,
+		},
+	}, nil
+}
+
+func (b *EthereumBackend) pathSignTx(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	_, err := b.configured(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	name := data.Get("name").(string)
+	account, err := b.readAccount(ctx, req, name)
+	if err != nil {
+		return nil, fmt.Errorf("error reading account")
+	}
+	if account == nil {
+		return nil, nil
+	}
+
+	// Read tx parameters from json body
+	value := ValidNumber(data.Get("value").(string))
+	if value == nil {
+		return nil, fmt.Errorf("invalid value")
+	}
+
+	chainID := ValidNumber(data.Get("chain_id").(string))
+	if chainID == nil {
+		return nil, fmt.Errorf("invalid chain ID")
+	}
+
+	nonceIn := ValidNumber(data.Get("nonce").(string))
+	if nonceIn == nil {
+		return nil, fmt.Errorf("invalid nonce")
+	}
+	nonce := nonceIn.Uint64()
+
+	gasLimitIn := ValidNumber(data.Get("gas_limit").(string))
+	if gasLimitIn == nil {
+		return nil, fmt.Errorf("invalid gas limit")
+	}
+	gasLimit := gasLimitIn.Uint64()
+
+	gasPrice := ValidNumber(data.Get("gas_price").(string))
+	if gasPrice == nil {
+		return nil, fmt.Errorf("invalid gas price")
+	}
+
+	hexAddress := data.Get("address_to").(string)
+	if !common.IsHexAddress(hexAddress) {
+		return nil, fmt.Errorf("invalid transaction receiver address")
+	}
+	addressTo := common.HexToAddress(data.Get("address_to").(string))
+
+	txData, err := hexutil.Decode(data.Get("tx_data").(string))
+	if err != nil {
+		return nil, err
+	}
+
+	privateKey, err := crypto.HexToECDSA(account.PrivateKey)
+	if err != nil {
+		return nil, err
+	}
+	defer ZeroKey(privateKey)
+
+	// Create transaction
+	tx := types.NewTransaction(nonce, addressTo, value, gasLimit, gasPrice, txData)
+	signedTx, err := types.SignTx(tx, types.NewEIP155Signer(chainID), privateKey)
+
+	// Encode raw transaction and prepare for pushing in network
+	var signedTxBuff bytes.Buffer
+	signedTx.EncodeRLP(&signedTxBuff)
+
+	return &logical.Response{
+		Data: map[string]interface{}{
+			"signed_tx": hexutil.Encode(signedTxBuff.Bytes()),
 			"address":   account.Address,
 		},
 	}, nil

--- a/swagger.json
+++ b/swagger.json
@@ -176,10 +176,6 @@
                 "gas_price": {
                   "type": "string",
                   "x-go-name": "gasPrice"
-                },
-                "chain_id": {
-                  "type": "string",
-                  "x-go-name": "chainId"
                 }
               }
             }

--- a/swagger.json
+++ b/swagger.json
@@ -129,6 +129,72 @@
         }
       }
     },
+    "/addresses/{address}/sign-tx": {
+      "post": {
+        "tags": [
+          "Addresses"
+        ],
+        "summary": "This endpoint will sign transaction.",
+        "operationId": "pathAddressesSignTx",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "Address",
+            "description": "The address to lookup",
+            "name": "address",
+            "in": "path",
+            "required": true
+          },
+          {
+            "x-go-name": "Data",
+            "name": "data",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "nonce": {
+                  "type": "string",
+                  "x-go-name": "Nonce"
+                },
+                "address_to": {
+                  "type": "string",
+                  "x-go-name": "AddressTo"
+                },
+                "value": {
+                  "type": "string",
+                  "x-go-name": "Value"
+                },
+                "tx_data": {
+                  "type": "string",
+                  "x-go-name": "txData"
+                },
+                "gas_limit": {
+                  "type": "string",
+                  "x-go-name": "gasLimit"
+                },
+                "gas_price": {
+                  "type": "string",
+                  "x-go-name": "gasPrice"
+                },
+                "chain_id": {
+                  "type": "string",
+                  "x-go-name": "chainId"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "SignerTransactionResponse",
+            "schema": {
+              "$ref": "#/definitions/SignerTransactionResponse"
+            }
+          }
+        }
+      }
+    },
     "/convert": {
       "put": {
         "tags": [
@@ -359,6 +425,59 @@
             "verified": {
               "type": "boolean",
               "x-go-name": "Verified"
+            }
+          },
+          "x-go-name": "Data"
+        },
+        "lease_duration": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "LeaseDuration"
+        },
+        "lease_id": {
+          "type": "string",
+          "x-go-name": "LeaseId"
+        },
+        "renewable": {
+          "type": "boolean",
+          "x-go-name": "Renewable"
+        },
+        "request_id": {
+          "type": "string",
+          "x-go-name": "RequestId"
+        },
+        "warnings": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "x-go-name": "Warnings"
+        },
+        "wrap_info": {
+          "type": "string",
+          "x-go-name": "WrapInfo"
+        }
+      },
+      "x-go-package": "github.com/zambien/vault-ethereum"
+    },
+    "SignerTransactionResponse": {
+      "description": "Signed transaction and public key of signer.",
+      "type": "object",
+      "properties": {
+        "auths": {
+          "type": "string",
+          "x-go-name": "Auth"
+        },
+        "data": {
+          "type": "object",
+          "properties": {
+            "address": {
+              "type": "string",
+              "x-go-name": "Address"
+            },
+            "signed_tx": {
+              "type": "string",
+              "x-go-name": "Signature"
             }
           },
           "x-go-name": "Data"


### PR DESCRIPTION
## Description
I'm sorry for the duplicate, but previous MR could not be reopened because HEAD was updated.

@cypherhat
Answering your previous questions:
1. Have you tested with both contract deploy transactions and send ETH transactions?
2. chain_id shouldn't be an input parameter. The mount point is configured for a particular chain_id.

Answers:
1. I've tested only sending ether and smart contracts functions calls and I think we already have great API for contracts deployment (but anyway if we will make `account_to` field optional - it will work for contracts deployment too.
2. Good point. I've just updated the code accordingly. 👍

## Motivation and Context
I'm tried common sign method, but it seems it's working only for custom data signatures. Anyway - I think we need a more developer's friendly way to sign the transaction.

The developer only needs to provide all `json` properties of the transaction and then he gets signed transaction in HEX format that ready to be broadcasted to Ethereum network by any convenient way. For example:
[Etherscan tool](https://etherscan.io/pushTx)
[How to broadcast transaction via web3](https://github.com/ethereum/wiki/wiki/JavaScript-API#web3ethsendrawtransaction)

## How Has This Been Tested?
This is a brand new API and does not impact any existing code. I've created signed transactions and broadcasted them on `Ropsten` network via [Etherscan publishing tool](https://ropsten.etherscan.io/pushTx)

## Types of changes
- [ ] Documentation enhancement
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.