### PR TITLE
Add -sha256 to the CSR signing command

### DIFF
--- a/helper/install_vault.sh
+++ b/helper/install_vault.sh
@@ -57,6 +57,7 @@ EOF
 
   openssl req \
     -new \
+    -sha256 \
     -newkey rsa:2048 \
     -days 120 \
     -nodes \
@@ -66,7 +67,7 @@ EOF
     -out "${TMPDIR}/ca.crt"
 
   # Generate the private key for the service. Again, you may want to increase
-  # the bits to 4096.
+  # the bits to 2048.
   openssl genrsa -out "${TMPDIR}/my-service.key" 2048
 
   # Generate a CSR using the configuration and the key just generated. We will
@@ -85,6 +86,7 @@ EOF
     -CA "${TMPDIR}/ca.crt" \
     -CAkey "${TMPDIR}/ca.key" \
     -CAcreateserial \
+    -sha256 \
     -extensions v3_req \
     -extfile "${TMPDIR}/openssl.cnf" \
     -out "${TMPDIR}/my-service.crt"

--- a/helper/install_vault.sh
+++ b/helper/install_vault.sh
@@ -20,7 +20,7 @@ function gencerts {
   cat > "${TMPDIR}/openssl.cnf" << EOF
 [req]
 default_bits = 2048
-encrypt_key  = no # Change to encrypt the private key using des3 or similar
+encrypt_key  = no 
 default_md   = sha256
 prompt       = no
 utf8         = yes


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This might be a LibreSSL issue, but it seems that OpenSSL+LibreSSL is ignoring the default_md

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Documentation enhancement
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
