### PR TITLE
curious change to REST mappings due to vault 0.11.2 which are incompatible with 0.11.1

### DIFF
--- a/API.md
+++ b/API.md
@@ -20,7 +20,7 @@ Vault provides a CLI that wraps the Vault REST interface. Any HTTP client (inclu
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`    ├── block `  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`    │   └── <NUMBER> `&nbsp;&nbsp;([read](./API.md#read-block))  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`    │       └── transactions `&nbsp;&nbsp;([read](./API.md#read-block-transactions))  
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`    ├── convert `&nbsp;&nbsp;([update](./API.md#convert))  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`    ├── convert `&nbsp;&nbsp;([create](./API.md#convert), [update](./API.md#convert))  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`    ├── export `  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`    │   └── <NAME> `&nbsp;&nbsp;([create](./API.md#export))  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`    ├── deploy `  
@@ -1125,7 +1125,7 @@ This endpoint will convert one Ethereum unit to another.
 
 | Method  | Path | Produces |
 | ------------- | ------------- | ------------- |
-| `POST`  | `:mount-path/convert`  | `200 application/json` |
+| `POST/PUT`  | `:mount-path/convert`  | `200 application/json` |
 
 #### Parameters
 
@@ -1146,7 +1146,7 @@ This endpoint will convert one Ethereum unit to another.
 
 ```sh
 $ curl -s --cacert ~/etc/vault.d/root.crt --header "X-Vault-Token: $VAULT_TOKEN" \
-    --request PUT \
+    --request POST \
     --data @convert.json \
     https://localhost:8200/v1/ethereum/convert | jq .
 ```

--- a/path_config.go
+++ b/path_config.go
@@ -74,7 +74,8 @@ func configPaths(b *EthereumBackend) []*framework.Path {
 		&framework.Path{
 			Pattern: "config",
 			Callbacks: map[logical.Operation]framework.OperationFunc{
-				logical.UpdateOperation: b.pathUpdateConfig,
+				logical.CreateOperation: b.pathWriteConfig,
+				logical.UpdateOperation: b.pathWriteConfig,
 				logical.ReadOperation:   b.pathReadConfig,
 			},
 			HelpSynopsis: "Configure the trustee plugin.",
@@ -154,7 +155,7 @@ func getDefaultNetwork(chainID string) string {
 	return Local
 }
 
-func (b *EthereumBackend) pathUpdateConfig(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+func (b *EthereumBackend) pathWriteConfig(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 	rpcURL := data.Get("rpc_url").(string)
 	apiKey := data.Get("api_key").(string)
 	chainID := data.Get("chain_id").(string)

--- a/path_config.go
+++ b/path_config.go
@@ -74,7 +74,6 @@ func configPaths(b *EthereumBackend) []*framework.Path {
 		&framework.Path{
 			Pattern: "config",
 			Callbacks: map[logical.Operation]framework.OperationFunc{
-				logical.CreateOperation: b.pathCreateConfig,
 				logical.UpdateOperation: b.pathUpdateConfig,
 				logical.ReadOperation:   b.pathReadConfig,
 			},
@@ -155,7 +154,7 @@ func getDefaultNetwork(chainID string) string {
 	return Local
 }
 
-func (b *EthereumBackend) pathCreateConfig(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+func (b *EthereumBackend) pathUpdateConfig(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 	rpcURL := data.Get("rpc_url").(string)
 	apiKey := data.Get("api_key").(string)
 	chainID := data.Get("chain_id").(string)
@@ -190,10 +189,6 @@ func (b *EthereumBackend) pathCreateConfig(ctx context.Context, req *logical.Req
 			"rpc_url":         configBundle.RPC,
 		},
 	}, nil
-}
-
-func (b *EthereumBackend) pathUpdateConfig(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
-	return b.pathCreateConfig(ctx, req, data)
 }
 
 func (b *EthereumBackend) pathReadConfig(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
@@ -241,7 +236,7 @@ func (b *EthereumBackend) readConfig(ctx context.Context, s logical.Storage) (*C
 func (b *EthereumBackend) configured(ctx context.Context, req *logical.Request) (*Config, error) {
 	config, err := b.readConfig(ctx, req.Storage)
 	if err != nil {
-		return nil, fmt.Errorf("backend not properly configured")
+		return nil, err
 	}
 	if validConnection, err := b.validIPConstraints(config, req); !validConnection {
 		return nil, err

--- a/path_convert.go
+++ b/path_convert.go
@@ -79,7 +79,7 @@ func convertPaths(b *EthereumBackend) []*framework.Path {
 			},
 			ExistenceCheck: b.pathExistenceCheck,
 			Callbacks: map[logical.Operation]framework.OperationFunc{
-				logical.UpdateOperation: b.pathConvertWrite,
+				logical.CreateOperation: b.pathConvertWrite,
 			},
 		},
 	}

--- a/path_convert.go
+++ b/path_convert.go
@@ -80,6 +80,7 @@ func convertPaths(b *EthereumBackend) []*framework.Path {
 			ExistenceCheck: b.pathExistenceCheck,
 			Callbacks: map[logical.Operation]framework.OperationFunc{
 				logical.CreateOperation: b.pathConvertWrite,
+				logical.UpdateOperation: b.pathConvertWrite,
 			},
 		},
 	}

--- a/swagger.json
+++ b/swagger.json
@@ -702,7 +702,64 @@
           "Config"
         ],
         "summary": "Handler which updates the configuration for the plugin.",
-        "operationId": "pathUpdateConfig",
+        "operationId": "pathWriteConfig",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "MountPath",
+            "description": "The endpoint configured for the plugin mount",
+            "name": "mount-path",
+            "in": "path",
+            "required": true
+          },
+          {
+            "x-go-name": "Data",
+            "description": "The conversion inputs",
+            "name": "data",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "api_key": {
+                  "type": "string",
+                  "x-go-name": "ApiKey"
+                },
+                "bound_cidr_list": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "x-go-name": "BoundCidrList"
+                },
+                "chain_id": {
+                  "type": "string",
+                  "x-go-name": "ChainId"
+                },
+                "rpc_url": {
+                  "type": "string",
+                  "x-go-name": "RpcUrl"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ConfigResponse",
+            "schema": {
+              "$ref": "#/definitions/ConfigResponse"
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "### This endpoint configures the plugin at a mount.\n\nNote, an empty body sets the defaults of rinkeby\n\n## Inputs:\n\n Name    | Type     | Required | Default | Description                |\n ------- | -------- | -------- | ---------| -------------------------- |\n mount-path   | string    | true  | | The endpoint configured for the plugin mount. |\n rpc_url   | string    | false  | https://rinkeby.infura.io | Specifies the RPC URL of the Ethereum node. |\n chain_id   | string    | false  | 4 |  Specifies the Ethereum network. Defaults to Rinkeby. |\n bound_cidr_list   | string    | false  | | Comma delimited list of allowed CIDR blocks. |\n api_key   | string    | false  | | The Infura API key. |",
+        "tags": [
+          "Config"
+        ],
+        "summary": "Handler which updates the configuration for the plugin.",
+        "operationId": "pathWriteConfig",
         "parameters": [
           {
             "type": "string",
@@ -756,6 +813,56 @@
     },
     "/{mount-path}/convert": {
       "post": {
+        "description": "### This endpoint will convert one Ethereum unit to another.\n\n## Inputs:\n\n Name    | Type     | Required | Description                |\n ------- | -------- | -------- | -------------------------- |\n mount-path   | string    | true  | The endpoint configured for the plugin mount. |\n amount   | string    | true  | Specifies amount to convert. |\n unit_from   | string    | true  | Specifies unit to convert from. |\n unit_to   | string    | true  | Specifies unit to convert to. |",
+        "tags": [
+          "Convert"
+        ],
+        "summary": "Handler returning various ETH conversions.",
+        "operationId": "pathConvertWrite",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "MountPath",
+            "description": "The endpoint configured for the plugin mount",
+            "name": "mount-path",
+            "in": "path",
+            "required": true
+          },
+          {
+            "x-go-name": "Data",
+            "description": "The conversion inputs",
+            "name": "data",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "amount": {
+                  "type": "string",
+                  "x-go-name": "AmountIn"
+                },
+                "unit_from": {
+                  "type": "string",
+                  "x-go-name": "UnitFromIn"
+                },
+                "unit_to": {
+                  "type": "string",
+                  "x-go-name": "UnitToIn"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ConversionResponse",
+            "schema": {
+              "$ref": "#/definitions/ConversionResponse"
+            }
+          }
+        }
+      },
+      "put": {
         "description": "### This endpoint will convert one Ethereum unit to another.\n\n## Inputs:\n\n Name    | Type     | Required | Description                |\n ------- | -------- | -------- | -------------------------- |\n mount-path   | string    | true  | The endpoint configured for the plugin mount. |\n amount   | string    | true  | Specifies amount to convert. |\n unit_from   | string    | true  | Specifies unit to convert from. |\n unit_to   | string    | true  | Specifies unit to convert to. |",
         "tags": [
           "Convert"

--- a/swagger.json
+++ b/swagger.json
@@ -752,67 +752,10 @@
             }
           }
         }
-      },
-      "post": {
-        "description": "### This endpoint configures the plugin at a mount.\n\nNote, an empty body sets the defaults of rinkeby\n\n## Inputs:\n\n Name    | Type     | Required | Default | Description                |\n ------- | -------- | -------- | ---------| -------------------------- |\n mount-path   | string    | true  | | The endpoint configured for the plugin mount. |\n rpc_url   | string    | false  | https://rinkeby.infura.io | Specifies the RPC URL of the Ethereum node. |\n chain_id   | string    | false  | 4 |  Specifies the Ethereum network. Defaults to Rinkeby. |\n bound_cidr_list   | string    | false  | | Comma delimited list of allowed CIDR blocks. |\n api_key   | string    | false  | | The Infura API key. |",
-        "tags": [
-          "Config"
-        ],
-        "summary": "Handler which creates the configuration for the plugin.",
-        "operationId": "pathCreateConfig",
-        "parameters": [
-          {
-            "type": "string",
-            "x-go-name": "MountPath",
-            "description": "The endpoint configured for the plugin mount",
-            "name": "mount-path",
-            "in": "path",
-            "required": true
-          },
-          {
-            "x-go-name": "Data",
-            "description": "The debit inputs",
-            "name": "data",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "type": "object",
-              "properties": {
-                "address_to": {
-                  "type": "string",
-                  "x-go-name": "AddressTo"
-                },
-                "amount": {
-                  "type": "string",
-                  "x-go-name": "Amount"
-                },
-                "gas_limit": {
-                  "type": "string",
-                  "x-go-name": "GasLimit"
-                },
-                "gas_price": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "x-go-name": "GasPrice"
-                }
-              }
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "ConfigResponse",
-            "schema": {
-              "$ref": "#/definitions/ConfigResponse"
-            }
-          }
-        }
       }
     },
     "/{mount-path}/convert": {
-      "put": {
+      "post": {
         "description": "### This endpoint will convert one Ethereum unit to another.\n\n## Inputs:\n\n Name    | Type     | Required | Description                |\n ------- | -------- | -------- | -------------------------- |\n mount-path   | string    | true  | The endpoint configured for the plugin mount. |\n amount   | string    | true  | Specifies amount to convert. |\n unit_from   | string    | true  | Specifies unit to convert from. |\n unit_to   | string    | true  | Specifies unit to convert to. |",
         "tags": [
           "Convert"

--- a/test/ethereum/config/config.bats
+++ b/test/ethereum/config/config.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 
 @test "test write rinkeby config" {
-  config="$(vault write -format=json ethereum/rinkeby/config @rinkeby.json | jq .data)"
+  config="$(vault write -format=json ethereum/dev/config @rinkeby.json | jq .data)"
   api_key="$(echo $config | jq -r .api_key)"
   bound_cidr_list="$(echo $config | jq -r .bound_cidr_list)"
   chain_id="$(echo $config | jq -r .chain_id)"
@@ -12,7 +12,7 @@
 }
 
 @test "test write mainnet config" {
-  config="$(vault write -format=json ethereum/mainnet/config @mainnet.json | jq .data)"
+  config="$(vault write -format=json ethereum/prod/config @mainnet.json | jq .data)"
   api_key="$(echo $config | jq -r .api_key)"
   bound_cidr_list="$(echo $config | jq -r .bound_cidr_list)"
   chain_id="$(echo $config | jq -r .chain_id)"
@@ -23,12 +23,12 @@
 }
 
 @test "test read config" {
-  config="$(vault write -format=json ethereum/mainnet/config @mainnet.json | jq .data)"
+  config="$(vault write -format=json ethereum/prod/config @mainnet.json | jq .data)"
   api_key="$(echo $config | jq -r .api_key)"
   bound_cidr_list="$(echo $config | jq -r .bound_cidr_list)"
   chain_id="$(echo $config | jq -r .chain_id)"
   rpc_url="$(echo $config | jq -r .rpc_url)"
-  read_config="$(vault read -format=json ethereum/mainnet/config | jq .data)"
+  read_config="$(vault read -format=json ethereum/prod/config | jq .data)"
   read_api_key="$(echo $read_config | jq -r .api_key)"
   read_bound_cidr_list="$(echo $read_config | jq -r .bound_cidr_list)"
   read_chain_id="$(echo $read_config | jq -r .chain_id)"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Had to add support for both PUT and POST due to incompatibilities in 0.11.1 and 0.11.2

## Motivation and Context
The plugin's convert operation didn't work under 0.11.2. Determined that in 0.11.1 the plugin was receiving a PUT and in 0.11.2 it was receiving a PUT.

## How Has This Been Tested?
Tested under both versions.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Documentation enhancement
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
