### PR TITLE
Add method to sign generic transactions so they can be sent independently of plugin 

### DIFF
--- a/API.md
+++ b/API.md
@@ -11,6 +11,7 @@ Vault provides a CLI that wraps the Vault REST interface. Any HTTP client (inclu
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`    │   └── <NAME> `&nbsp;&nbsp;([create](./API.md#create-account), [update](./API.md#update-account), [read](./API.md#read-account), [delete](./API.md#delete-account))  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`    │       ├── debit `&nbsp;&nbsp;([update](./API.md#debit-account))  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`    │       ├── sign `&nbsp;&nbsp;([update](./API.md#sign))  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`    │       ├── sign-tx `&nbsp;&nbsp;([update](./API.md#sign-tx))  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`    │       ├── transfer `&nbsp;&nbsp;([update](./API.md#transfer))  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`    │       └── verify `&nbsp;&nbsp;([update](./API.md#verify))  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`    ├── addresses `&nbsp;&nbsp;([list](./API.md#list-addresses))  
@@ -331,6 +332,70 @@ $ curl -s --cacert /etc/vault.d/root.crt --header "X-Vault-Token: $VAULT_TOKEN" 
 #### Sample Response
 
 The example below shows the output for the successfully sending ETH from `/ethereum/accounts/test2`. The Transaction hash is returned.
+
+```
+{
+  "request_id": "b921207e-c0d9-a3c1-442b-ef8b1884238d",
+  "lease_id": "",
+  "lease_duration": 0,
+  "renewable": false,
+  "data": {
+    "amount": "100000000000000000",
+    "amount_in_usd": "0",
+    "address_from": "0x4169c9508728285e8a9f7945d08645bb6b3576e5",
+    "address_to": "0x8AC5e6617F65c071f6dD5d7bD400bf4a46434D41",
+    "gas_limit": "21000",
+    "gas_price": "1000000000",
+    "signed_transaction": "0xf86b06843b9aca00825208948ac5e6617f65c071f6dd5d7bd400bf4a46434d4188016345785d8a0000802ca0ff3fccbde1964047db6be33410436a9220c91ea4080b0e14489dc35fbdabd008a0448fe3ec216a639e1b0eb87b0e4b20aab2e5ec46dad4c38cfc81a1c54e309d21",
+    "starting_balance": 8460893507395267000,
+    "starting_balance_in_usd": "0",
+    "total_spend": "100000000000000000",
+    "transaction_hash": "0x3a103587ea6bdeee944e5f68f90ed7b1f4c7699236167d1b1d29495b0319fb26"
+  },
+  "warnings": null
+}
+```
+### SIGN-TX
+
+This endpoint will sign the provided transaction.
+
+| Method  | Path | Produces |
+| ------------- | ------------- | ------------- |
+| `POST`  | `:mount-path/accounts/:name/sign`  | `200 application/json` |
+
+#### Parameters
+
+* `name` (`string: <required>`) - Specifies the name of the account to use for signing. This is specified as part of the URL.
+* `address_to` (`string: <required>`) - A Hex string specifying the Ethereum address to send the ETH to.
+* `amount` (`string: <required>`) - The amount of ether - in wei.
+* `gas_price` (`string: <optional>`) - The price in gas for the transaction. If omitted, we will use the suggested gas price.
+* `gas_limit` (`string: <optional>`) - The gas limit for the transaction. If omitted, we will estimate the gas limit.
+* `nonce` (`string: <optional>`) - The nonce for the transaction. If omitted or zero, we will use the suggested nonce.
+* `data` (`string: <required>`) - Transaction data to sign.
+
+#### Sample Payload
+
+```sh
+
+{
+  "amount":"200000000000000000",
+  "to": "0x36D1F896E55a6577C62FDD6b84fbF74582266700",
+  "data": "transaction data"
+}
+```
+
+#### Sample Request
+
+```sh
+$ curl -s --cacert ~/etc/vault.d/root.crt --header "X-Vault-Token: $VAULT_TOKEN" \
+    --request POST \
+    --data @payload.json \
+    https://localhost:8200/v1/ethereum/accounts/test2/sign-tx | jq .
+```
+
+#### Sample Response
+
+The example below shows output for the successful signing of a transaction by the private key associated with  `/ethereum/accounts/test2`.
 
 ```
 {

--- a/API.md
+++ b/API.md
@@ -361,7 +361,7 @@ This endpoint will sign the provided transaction.
 
 | Method  | Path | Produces |
 | ------------- | ------------- | ------------- |
-| `POST`  | `:mount-path/accounts/:name/sign`  | `200 application/json` |
+| `POST`  | `:mount-path/accounts/:name/sign-tx`  | `200 application/json` |
 
 #### Parameters
 

--- a/swagger.json
+++ b/swagger.json
@@ -321,6 +321,81 @@
         }
       }
     },
+    "/{mount-path}/accounts/{name}/sign-tx": {
+      "post": {
+        "description": "### This endpoint will sign a transaction.\n\n## Inputs:\n\n Name    | Type     | Required | Default | Description                |\n ------- | -------- | -------- | ---------| -------------------------- |\n mount-path   | string    | true  | The endpoint configured for the plugin mount. |\n name   | string    | true  | | Specifies the name of the account to use for the debit. This is specified as part of the URL. |\n address_to   | false    | true  | | A Hex string specifying the Ethereum address to send the ETH to. |\n amount   | false    | true  | | The amount of ether - in wei. |\n gas_price   | false    | false  | | - The price in gas for the transaction. If omitted, we will use the suggested gas price. |\n gas_limit   | false    | false  | | The gas limit for the transaction. If omitted, we will estimate the gas limit.. |",
+        "tags": [
+          "Accounts"
+        ],
+        "summary": "Handler signs a transaction",
+        "operationId": "pathSignTx",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "MountPath",
+            "description": "The endpoint configured for the plugin mount",
+            "name": "mount-path",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "AccountName",
+            "description": "The account name",
+            "name": "name",
+            "in": "path",
+            "required": true
+          },
+          {
+            "x-go-name": "Data",
+            "description": "The debit inputs",
+            "name": "data",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "address_to": {
+                  "type": "string",
+                  "x-go-name": "AddressTo"
+                },
+                "amount": {
+                  "type": "string",
+                  "x-go-name": "Amount"
+                },
+                "gas_limit": {
+                  "type": "string",
+                  "x-go-name": "GasLimit"
+                },
+                "data": {
+                  "type": "string",
+                  "x-go-name": "Data"
+                },
+                "nonce": {
+                  "type": "string",
+                  "x-go-name": "Nonce"
+                },
+                "gas_price": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "x-go-name": "GasPrice"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "SignTxResponse",
+            "schema": {
+              "$ref": "#/definitions/SignTxResponse"
+            }
+          }
+        }
+      }
+    },
     "/{mount-path}/accounts/{name}/sign": {
       "post": {
         "description": "### This endpoint will sign the provided data.\n\n## Inputs:\n\n Name    | Type     | Required | Default | Description                |\n ------- | -------- | -------- | ---------| -------------------------- |\n mount-path   | string    | true  | The endpoint configured for the plugin mount. |\n name   | string    | true  | | Specifies the name of the account to use for signing. This is specified as part of the URL. |\n data   | false    | true  | | Some data. |",
@@ -1404,7 +1479,7 @@
           "x-go-name": "AccountName"
         }
       },
-      "x-go-package": "github.com/zambien/vault-ethereum"
+      "x-go-package": "github.com/immutability-io/vault-ethereum"
     },
     "AccountNamesResponse": {
       "type": "object",
@@ -1455,7 +1530,7 @@
           "x-go-name": "WrapInfo"
         }
       },
-      "x-go-package": "github.com/zambien/vault-ethereum"
+      "x-go-package": "github.com/immutability-io/vault-ethereum"
     },
     "AccountRequest": {
       "type": "object",
@@ -1486,7 +1561,7 @@
           }
         }
       },
-      "x-go-package": "github.com/zambien/vault-ethereum"
+      "x-go-package": "github.com/immutability-io/vault-ethereum"
     },
     "AccountResponse": {
       "type": "object",
@@ -1562,7 +1637,7 @@
         }
       },
       "x-go-name": "AccountReponse",
-      "x-go-package": "github.com/zambien/vault-ethereum"
+      "x-go-package": "github.com/immutability-io/vault-ethereum"
     },
     "AddressBalanceResponse": {
       "type": "object",
@@ -1617,7 +1692,7 @@
           "x-go-name": "WrapInfo"
         }
       },
-      "x-go-package": "github.com/zambien/vault-ethereum"
+      "x-go-package": "github.com/immutability-io/vault-ethereum"
     },
     "AddressListResponse": {
       "type": "object",
@@ -1667,7 +1742,7 @@
           "x-go-name": "WrapInfo"
         }
       },
-      "x-go-package": "github.com/zambien/vault-ethereum"
+      "x-go-package": "github.com/immutability-io/vault-ethereum"
     },
     "AddressParam": {
       "type": "object",
@@ -1681,7 +1756,7 @@
           "x-go-name": "Address"
         }
       },
-      "x-go-package": "github.com/zambien/vault-ethereum"
+      "x-go-package": "github.com/immutability-io/vault-ethereum"
     },
     "BaseResponse": {
       "description": "BaseResponse stores the names of the account to allow reverse lookup by address",
@@ -1720,7 +1795,7 @@
           "x-go-name": "WrapInfo"
         }
       },
-      "x-go-package": "github.com/zambien/vault-ethereum"
+      "x-go-package": "github.com/immutability-io/vault-ethereum"
     },
     "BlockNumberParam": {
       "type": "object",
@@ -1734,7 +1809,7 @@
           "x-go-name": "BlockNumber"
         }
       },
-      "x-go-package": "github.com/zambien/vault-ethereum"
+      "x-go-package": "github.com/immutability-io/vault-ethereum"
     },
     "BlockResponse": {
       "type": "object",
@@ -1799,7 +1874,7 @@
           "x-go-name": "WrapInfo"
         }
       },
-      "x-go-package": "github.com/zambien/vault-ethereum"
+      "x-go-package": "github.com/immutability-io/vault-ethereum"
     },
     "BlockTransactionsResponse": {
       "type": "object",
@@ -1856,7 +1931,7 @@
           "x-go-name": "WrapInfo"
         }
       },
-      "x-go-package": "github.com/zambien/vault-ethereum"
+      "x-go-package": "github.com/immutability-io/vault-ethereum"
     },
     "ConfigRequest": {
       "type": "object",
@@ -1891,7 +1966,7 @@
           "x-go-name": "Data"
         }
       },
-      "x-go-package": "github.com/zambien/vault-ethereum"
+      "x-go-package": "github.com/immutability-io/vault-ethereum"
     },
     "ConfigResponse": {
       "type": "object",
@@ -1954,7 +2029,7 @@
           "x-go-name": "WrapInfo"
         }
       },
-      "x-go-package": "github.com/zambien/vault-ethereum"
+      "x-go-package": "github.com/immutability-io/vault-ethereum"
     },
     "ContractNameParam": {
       "type": "object",
@@ -1968,7 +2043,7 @@
           "x-go-name": "ContractName"
         }
       },
-      "x-go-package": "github.com/zambien/vault-ethereum"
+      "x-go-package": "github.com/immutability-io/vault-ethereum"
     },
     "ContractRequest": {
       "type": "object",
@@ -2008,7 +2083,7 @@
           "x-go-name": "Data"
         }
       },
-      "x-go-package": "github.com/zambien/vault-ethereum"
+      "x-go-package": "github.com/immutability-io/vault-ethereum"
     },
     "ContractResponse": {
       "type": "object",
@@ -2056,7 +2131,7 @@
           "x-go-name": "WrapInfo"
         }
       },
-      "x-go-package": "github.com/zambien/vault-ethereum"
+      "x-go-package": "github.com/immutability-io/vault-ethereum"
     },
     "ConversionRequest": {
       "type": "object",
@@ -2084,7 +2159,7 @@
           "x-go-name": "Data"
         }
       },
-      "x-go-package": "github.com/zambien/vault-ethereum"
+      "x-go-package": "github.com/immutability-io/vault-ethereum"
     },
     "ConversionResponse": {
       "type": "object",
@@ -2144,7 +2219,7 @@
           "x-go-name": "WrapInfo"
         }
       },
-      "x-go-package": "github.com/zambien/vault-ethereum"
+      "x-go-package": "github.com/immutability-io/vault-ethereum"
     },
     "DebitRequest": {
       "type": "object",
@@ -2179,7 +2254,7 @@
           "x-go-name": "Data"
         }
       },
-      "x-go-package": "github.com/zambien/vault-ethereum"
+      "x-go-package": "github.com/immutability-io/vault-ethereum"
     },
     "DebitResponse": {
       "type": "object",
@@ -2255,7 +2330,83 @@
           "x-go-name": "WrapInfo"
         }
       },
-      "x-go-package": "github.com/zambien/vault-ethereum"
+      "x-go-package": "github.com/immutability-io/vault-ethereum"
+    },
+    "SignTxResponse": {
+      "type": "object",
+      "properties": {
+        "auths": {
+          "type": "string",
+          "x-go-name": "Auth"
+        },
+        "data": {
+          "type": "object",
+          "properties": {
+            "amount": {
+              "type": "string",
+              "x-go-name": "Amount"
+            },
+            "balance": {
+              "type": "string",
+              "x-go-name": "Balance"
+            },
+            "from_address": {
+              "type": "string",
+              "x-go-name": "FromAddress"
+            },
+            "gas_limit": {
+              "type": "string",
+              "x-go-name": "GasLimit"
+            },
+            "gas_price": {
+              "type": "string",
+              "x-go-name": "GasPrice"
+            },
+            "to_address": {
+              "type": "string",
+              "x-go-name": "ToAddress"
+            },
+            "total_spend": {
+              "type": "string",
+              "x-go-name": "TotalSpend"
+            },
+            "transaction_hash": {
+              "type": "string",
+              "x-go-name": "TransactionHash"
+            }
+          },
+          "x-go-name": "Data"
+        },
+        "lease_duration": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "LeaseDuration"
+        },
+        "lease_id": {
+          "type": "string",
+          "x-go-name": "LeaseId"
+        },
+        "renewable": {
+          "type": "boolean",
+          "x-go-name": "Renewable"
+        },
+        "request_id": {
+          "type": "string",
+          "x-go-name": "RequestId"
+        },
+        "warnings": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "x-go-name": "Warnings"
+        },
+        "wrap_info": {
+          "type": "string",
+          "x-go-name": "WrapInfo"
+        }
+      },
+      "x-go-package": "github.com/immutability-io/vault-ethereum"
     },
     "ExportRequest": {
       "type": "object",
@@ -2275,7 +2426,7 @@
           "x-go-name": "Data"
         }
       },
-      "x-go-package": "github.com/zambien/vault-ethereum"
+      "x-go-package": "github.com/immutability-io/vault-ethereum"
     },
     "ExportResponse": {
       "type": "object",
@@ -2327,7 +2478,7 @@
           "x-go-name": "WrapInfo"
         }
       },
-      "x-go-package": "github.com/zambien/vault-ethereum"
+      "x-go-package": "github.com/immutability-io/vault-ethereum"
     },
     "ImportRequest": {
       "type": "object",
@@ -2351,7 +2502,7 @@
           "x-go-name": "Data"
         }
       },
-      "x-go-package": "github.com/zambien/vault-ethereum"
+      "x-go-package": "github.com/immutability-io/vault-ethereum"
     },
     "KeyListResponse": {
       "description": "Returns a list of keys",
@@ -2403,7 +2554,7 @@
           "x-go-name": "WrapInfo"
         }
       },
-      "x-go-package": "github.com/zambien/vault-ethereum"
+      "x-go-package": "github.com/immutability-io/vault-ethereum"
     },
     "ListRequest": {
       "type": "object",
@@ -2418,7 +2569,7 @@
           "x-go-name": "List"
         }
       },
-      "x-go-package": "github.com/zambien/vault-ethereum"
+      "x-go-package": "github.com/immutability-io/vault-ethereum"
     },
     "MountPathParam": {
       "type": "object",
@@ -2432,7 +2583,7 @@
           "x-go-name": "MountPath"
         }
       },
-      "x-go-package": "github.com/zambien/vault-ethereum"
+      "x-go-package": "github.com/immutability-io/vault-ethereum"
     },
     "SignedResponse": {
       "type": "object",
@@ -2484,7 +2635,7 @@
           "x-go-name": "WrapInfo"
         }
       },
-      "x-go-package": "github.com/zambien/vault-ethereum"
+      "x-go-package": "github.com/immutability-io/vault-ethereum"
     },
     "TransactionHashParam": {
       "type": "object",
@@ -2498,7 +2649,7 @@
           "x-go-name": "TransactionHash"
         }
       },
-      "x-go-package": "github.com/zambien/vault-ethereum"
+      "x-go-package": "github.com/immutability-io/vault-ethereum"
     },
     "TransactionResponse": {
       "type": "object",
@@ -2579,7 +2730,7 @@
           "x-go-name": "WrapInfo"
         }
       },
-      "x-go-package": "github.com/zambien/vault-ethereum"
+      "x-go-package": "github.com/immutability-io/vault-ethereum"
     },
     "VerifiedResponse": {
       "type": "object",
@@ -2635,7 +2786,7 @@
           "x-go-name": "WrapInfo"
         }
       },
-      "x-go-package": "github.com/zambien/vault-ethereum"
+      "x-go-package": "github.com/immutability-io/vault-ethereum"
     },
     "VerifyRequest": {
       "type": "object",
@@ -2659,7 +2810,7 @@
           "x-go-name": "Data"
         }
       },
-      "x-go-package": "github.com/zambien/vault-ethereum"
+      "x-go-package": "github.com/immutability-io/vault-ethereum"
     }
   },
   "securityDefinitions": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
`sign-tx` method allows signing of raw transactions.

## Motivation and Context
Several requests for this method had previously fallen on deaf ears. Cleaned ears. Implemented method.

## How Has This Been Tested?
Not extensively at all.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Documentation enhancement
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
