### PR TITLE
Moved to coinmarketcap API pro/v1

### DIFF
--- a/API.md
+++ b/API.md
@@ -1040,7 +1040,7 @@ This endpoint configure the plugin at a mount.
 * `rpc_url` (`string: <optional> default:"https://rinkeby.infura.io"`) - Specifies the RPC URL of the Ethereum node.
 * `chain_id` (`string: <optional> default:"4"`) - Specifies the Ethereum network. Defaults to Rinkeby.
 * `bound_cidr_list` (`string array: <optional>`) - Comma delimited list of allowed CIDR blocks.
-* `api_key` (`string: <optional>`) - The Infura API key.
+* `api_key` (`string: <optional>`) - The Coinmarketcap API key.
 
 #### Sample Payload
 
@@ -1097,7 +1097,7 @@ This endpoint reconfigures the plugin at a mount.
 * `rpc_url` (`string: <optional> default:"https://rinkeby.infura.io"`) - Specifies the RPC URL of the Ethereum node.
 * `chain_id` (`string: <optional> default:"4"`) - Specifies the Ethereum network. Defaults to Rinkeby.
 * `bound_cidr_list` (`string array: <optional>`) - Comma delimited list of allowed CIDR blocks.
-* `api_key` (`string: <optional>`) - The Infura API key.
+* `api_key` (`string: <optional>`) - The Coinmarketcap API key.
 
 #### Sample Payload
 

--- a/path_accounts.go
+++ b/path_accounts.go
@@ -678,7 +678,7 @@ func (b *EthereumBackend) pathSignTx(ctx context.Context, req *logical.Request, 
 	}
 	amountInUSD, _ := decimal.NewFromString("0")
 	if config.ChainID == EthereumMainnet {
-		amountInUSD, err = ConvertToUSD(amount.String())
+		amountInUSD, err = ConvertToUSD(amount.String(), config.CoinMarketCapAPIKey)
 		if err != nil {
 			return nil, err
 		}
@@ -791,7 +791,7 @@ func (b *EthereumBackend) pathDebit(ctx context.Context, req *logical.Request, d
 	}
 	amountInUSD, _ := decimal.NewFromString("0")
 	if config.ChainID == EthereumMainnet {
-		amountInUSD, err = ConvertToUSD(amount.String())
+		amountInUSD, err = ConvertToUSD(amount.String(), config.CoinMarketCapAPIKey)
 		if err != nil {
 			return nil, err
 		}
@@ -980,7 +980,7 @@ func (b *EthereumBackend) readAccountBalanceByAddress(ctx context.Context, req *
 	}
 	// Calculate exchange rate value if on Mainnet
 	if config.ChainID == EthereumMainnet {
-		exchangeValue, err := ConvertToUSD(balance.String())
+		exchangeValue, err := ConvertToUSD(balance.String(), config.CoinMarketCapAPIKey)
 		if err != nil {
 			return nil, zero, err
 		}

--- a/path_config.go
+++ b/path_config.go
@@ -17,7 +17,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/helper/cidrutil"
@@ -118,12 +117,6 @@ IP addresses which can perform the login operation.`,
 }
 
 func (config *Config) getRPCURL() string {
-	if config.CoinMarketCapAPIKey != "" {
-		url := strings.TrimRight(config.RPC, "/")
-		if isInfuraNetwork(url) {
-			return fmt.Sprintf("%s/%s", url, config.CoinMarketCapAPIKey)
-		}
-	}
 	return config.RPC
 }
 

--- a/path_config.go
+++ b/path_config.go
@@ -63,10 +63,10 @@ const (
 
 // Config contains the configuration for each mount
 type Config struct {
-	BoundCIDRList []string `json:"bound_cidr_list_list" structs:"bound_cidr_list" mapstructure:"bound_cidr_list"`
-	RPC           string   `json:"rpc_url"`
-	InfuraAPIKey  string   `json:"api_key"`
-	ChainID       string   `json:"chain_id"`
+	BoundCIDRList       []string `json:"bound_cidr_list_list" structs:"bound_cidr_list" mapstructure:"bound_cidr_list"`
+	RPC                 string   `json:"rpc_url"`
+	CoinMarketCapAPIKey string   `json:"api_key"`
+	ChainID             string   `json:"chain_id"`
 }
 
 func configPaths(b *EthereumBackend) []*framework.Path {
@@ -105,7 +105,7 @@ func configPaths(b *EthereumBackend) []*framework.Path {
 				},
 				"api_key": &framework.FieldSchema{
 					Type:        framework.TypeString,
-					Description: `The Infura API Key.`,
+					Description: `The Coinmarketcap API Key.`,
 				},
 				"bound_cidr_list": &framework.FieldSchema{
 					Type: framework.TypeCommaStringSlice,
@@ -118,10 +118,10 @@ IP addresses which can perform the login operation.`,
 }
 
 func (config *Config) getRPCURL() string {
-	if config.InfuraAPIKey != "" {
+	if config.CoinMarketCapAPIKey != "" {
 		url := strings.TrimRight(config.RPC, "/")
 		if isInfuraNetwork(url) {
-			return fmt.Sprintf("%s/%s", url, config.InfuraAPIKey)
+			return fmt.Sprintf("%s/%s", url, config.CoinMarketCapAPIKey)
 		}
 	}
 	return config.RPC
@@ -167,10 +167,10 @@ func (b *EthereumBackend) pathWriteConfig(ctx context.Context, req *logical.Requ
 		boundCIDRList = boundCIDRListRaw.([]string)
 	}
 	configBundle := Config{
-		BoundCIDRList: boundCIDRList,
-		RPC:           rpcURL,
-		ChainID:       chainID,
-		InfuraAPIKey:  apiKey,
+		BoundCIDRList:       boundCIDRList,
+		RPC:                 rpcURL,
+		ChainID:             chainID,
+		CoinMarketCapAPIKey: apiKey,
 	}
 	entry, err := logical.StorageEntryJSON("config", configBundle)
 
@@ -186,7 +186,7 @@ func (b *EthereumBackend) pathWriteConfig(ctx context.Context, req *logical.Requ
 		Data: map[string]interface{}{
 			"bound_cidr_list": configBundle.BoundCIDRList,
 			"chain_id":        configBundle.ChainID,
-			"api_key":         configBundle.InfuraAPIKey,
+			"api_key":         configBundle.CoinMarketCapAPIKey,
 			"rpc_url":         configBundle.RPC,
 		},
 	}, nil
@@ -207,7 +207,7 @@ func (b *EthereumBackend) pathReadConfig(ctx context.Context, req *logical.Reque
 		Data: map[string]interface{}{
 			"bound_cidr_list": configBundle.BoundCIDRList,
 			"chain_id":        configBundle.ChainID,
-			"api_key":         configBundle.InfuraAPIKey,
+			"api_key":         configBundle.CoinMarketCapAPIKey,
 			"rpc_url":         configBundle.RPC,
 		},
 	}, nil

--- a/path_contracts.go
+++ b/path_contracts.go
@@ -218,7 +218,7 @@ func (b *EthereumBackend) pathCreateContract(ctx context.Context, req *logical.R
 	}
 	amountInUSD, _ := decimal.NewFromString("0")
 	if config.ChainID == EthereumMainnet {
-		amountInUSD, err = ConvertToUSD(amount.String())
+		amountInUSD, err = ConvertToUSD(amount.String(), config.CoinMarketCapAPIKey)
 		if err != nil {
 			return nil, err
 		}

--- a/test/ethereum/config/config.bats
+++ b/test/ethereum/config/config.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 
 @test "test write rinkeby config" {
-  config="$(vault write -format=json ethereum/dev/config @rinkeby.json | jq .data)"
+  config="$(vault write -format=json ethereum/dev/config rpc_url="https://rinkeby.infura.io" chain_id="4" | jq .data)"
   api_key="$(echo $config | jq -r .api_key)"
   bound_cidr_list="$(echo $config | jq -r .bound_cidr_list)"
   chain_id="$(echo $config | jq -r .chain_id)"
@@ -12,18 +12,18 @@
 }
 
 @test "test write mainnet config" {
-  config="$(vault write -format=json ethereum/prod/config @mainnet.json | jq .data)"
+  config="$(vault write -format=json ethereum/prod/config rpc_url="https://mainnet.infura.io" chain_id="1" api_key="$COINMARKETCAP_API_KEY"  | jq .data)"
   api_key="$(echo $config | jq -r .api_key)"
   bound_cidr_list="$(echo $config | jq -r .bound_cidr_list)"
   chain_id="$(echo $config | jq -r .chain_id)"
   rpc_url="$(echo $config | jq -r .rpc_url)"
-    [ "$api_key" = "" ]
+    [ "$api_key" = "$COINMARKETCAP_API_KEY" ]
     [ "$chain_id" = "1" ]
     [ "$rpc_url" = "https://mainnet.infura.io" ]
 }
 
 @test "test read config" {
-  config="$(vault write -format=json ethereum/prod/config @mainnet.json | jq .data)"
+  config="$(vault write -format=json ethereum/prod/config rpc_url="https://mainnet.infura.io" chain_id="1" api_key="$COINMARKETCAP_API_KEY"  | jq .data)"
   api_key="$(echo $config | jq -r .api_key)"
   bound_cidr_list="$(echo $config | jq -r .bound_cidr_list)"
   chain_id="$(echo $config | jq -r .chain_id)"

--- a/test/ethereum/config/mainnet.json
+++ b/test/ethereum/config/mainnet.json
@@ -1,4 +1,0 @@
-{
-  "rpc_url": "https://mainnet.infura.io",
-  "chain_id": "1"
-}

--- a/test/ethereum/config/rinkeby.json
+++ b/test/ethereum/config/rinkeby.json
@@ -1,4 +1,0 @@
-{
-  "rpc_url": "https://rinkeby.infura.io",
-  "chain_id": "4"
-}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Moved to using the pro version of the Coinmarketcap API. The configuration variable `api_key` was previously defined to be the Infura API key. That was actually a documentation/design error - the Infura API key can be simply added to the Infura URL - there was no need for an Infura API key.

## Motivation and Context
The Coinmarketcap v1 and v2 APIs are going away. The pro version (v1) is a completely different API. It requires an API Key - but there is a free tier (the hobbyist tier). This tier is rate limited.

## How Has This Been Tested?
Tested convert operation with and without `api_key` being configured.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Documentation enhancement
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
