### PR TITLE
Add Support to Eth_Sign

### DIFF
--- a/docker/demo.sh
+++ b/docker/demo.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 MNEMONIC="volcano story trust file before member board recycle always draw fiction when"
 CHAIN_ID=5777
@@ -6,6 +6,7 @@ PORT=8545
 RPC_URL="http://ganache:$PORT"
 PLUGIN="vault-ethereum"
 RAW_TX="f86d8202b28477359400825208944592d8f8d7b001e72cb26a73e4fa1806a51ac79d880de0b6b3a7640000802ca05924bde7ef10aa88db9c66dd4f5fb16b46dff2319b9968be983118b57bb50562a001b24b31010004f13d9a26b320845257a6cfc2bf819a3d55e3fc86263c5f0772"
+MESSAGE="HOLA VAULT"
 
 function header() {
   printf "## %s\n\n" "$@"
@@ -111,3 +112,9 @@ header "HOW TO SIGN A TRANSACTION WITH DATA"
 vault_command "vault write -format=json $PLUGIN/accounts/alice/sign-tx to='$BOB_ADDRESS' data='$RAW_TX' amount='20000000000000000'"
 curl_command $(vault write -output-curl-string $PLUGIN/accounts/alice/sign-tx to="$BOB_ADDRESS" data="$RAW_TX" amount='20000000000000000')
 log $(vault write -format=json $PLUGIN/accounts/alice/sign-tx to="$BOB_ADDRESS" data="$RAW_TX" amount='20000000000000000' | jq .)
+
+header "HOW TO SIGN MESSAGE. Message signature can be verify on: https://etherscan.io/verifySig/2156" 
+vault_command "vault write -format=json $PLUGIN/accounts/bob/sign message='$MESSAGE'"
+curl_command $(vault write -output-curl-string $PLUGIN/accounts/bob/sign message="$MESSAGE")
+log $(vault write -format=json $PLUGIN/accounts/bob/sign message="$MESSAGE"  | jq .)
+


### PR DESCRIPTION
## Description
Add new endpoint supporting: sign messages  an ECDSA signature for:

keccack256("\x19Ethereum Signed Message:\n" + len(message) + message).

More info: https://eth.wiki/json-rpc/API#eth_sign

## Motivation and Context
Users need to sign messages for example for Gasless transactions

## How Has This Been Tested?
For the moment it has been only been tested on a development environment. But the signature has been validated here: https://etherscan.io/verifySig/2156 


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Documentation enhancement
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
