### PR TITLE
update signTx and base docker image name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN mkdir -p /build/bin \
     && CGO_ENABLED=1 GOOS=linux go build -a -v -i -o /build/bin/vault-ethereum . \
     && sha256sum -b /build/bin/vault-ethereum > /build/bin/SHA256SUMS
 
-FROM vault:latest
+FROM hashicorp/vault:latest
 ARG always_upgrade
 RUN echo ${always_upgrade} > /dev/null && apk update && apk upgrade
 RUN apk add bash openssl jq

--- a/path_accounts.go
+++ b/path_accounts.go
@@ -652,7 +652,7 @@ func (b *PluginBackend) pathTransfer(ctx context.Context, req *logical.Request, 
 	}
 
 	tx := types.NewTransaction(transactionParams.Nonce, *transactionParams.Address, transactionParams.Amount, transactionParams.GasLimit, transactionParams.GasPrice, txDataToSign)
-	signedTx, err := wallet.SignTx(*account, tx, chainID)
+	signedTx, err := wallet.SignTxEIP155(*account, tx, chainID)
 	if err != nil {
 		return nil, err
 	}
@@ -816,7 +816,7 @@ func (b *PluginBackend) pathSignTx(ctx context.Context, req *logical.Request, da
 
 	tx := types.NewTransaction(transactionParams.Nonce, *transactionParams.Address, transactionParams.Amount, transactionParams.GasLimit, transactionParams.GasPrice, txDataToSign)
 
-	signedTx, err := wallet.SignTx(*account, tx, chainID)
+	signedTx, err := wallet.SignTxEIP155(*account, tx, chainID)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description
Make the signing transactions use EIP155 method to be able to work with current blockchain networks

Update base docker image name due to the notice in https://github.com/hashicorp/docker-vault where it states:
"Upcoming in Vault 1.14, we will stop publishing official Dockerhub images and publish only our Verified Publisher images. Users of Docker images should pull from hashicorp/vault instead of vault."

## Motivation and Context
It makes the project to be able to run without any new changes to project code

## How Has This Been Tested?
After using the makefile docker-build and run commands network is configured to use Polygon network and transactions are tested through the transfer endpoint of the account

## Types of changes
- [ ] Documentation enhancement
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.